### PR TITLE
Upgraded reduce condition on `String` implementation of `Smaller` protocol

### DIFF
--- a/quickcheck.swift
+++ b/quickcheck.swift
@@ -110,7 +110,7 @@ extension Int: Smaller {
 
 extension String: Smaller {
     func smaller() -> String? {
-        return isEmpty ? nil : String(characters.dropFirst())
+        return characters.count == 1 ? nil : String(characters.dropFirst())
     }
 }
 


### PR DESCRIPTION
We used to implement `Smaller` protocol on `String` so that it returns a new string, without a first character, for all non-empty strings. This would reduce all strings to an empty string when running `smaller` function repeatedly. New implementation defines smallest `String` as a single character string, which prevents the occurrence of the empty string as a result of `smaller` function.

Example:
Before running `smaller` repeatedly on "Hello" string would output "ello", "llo", "lo", "o", "".
Now running `smaller` repeatedly on "Hello" string would output "ello", "llo", "lo", "o".

Note: 
This PR is just a suggestion, as it's a small change and it would require update of the book feel free to backlog it or reject 